### PR TITLE
Fixes 0.2.0 version reference

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Comsat does provide one new API that you may choose to use: [Web Actors](manual/
 
 ### July 23, 2014
 
-Comsat [0.2.0](https://github.com/puniverse/comsat/releases/tag/v0.2.0 has been released.
+COMSAT [0.2.0](https://github.com/puniverse/comsat/releases/tag/v0.2.0) has been released.
 
 ### January 22, 2014
 


### PR DESCRIPTION
Not fixing the "Adapther" typo as it corresponds to the same typo in code.

javadocs don't build for me: the task seems not to find the MD doclet, will look into it later.
