### PR TITLE
Fixes javadocs build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,14 @@
+allprojects {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven { url "https://oss.sonatype.org/content/repositories/releases" }
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+        maven { url 'https://maven.java.net/content/repositories/snapshots' }
+        maven { url 'http://www.allanbank.com/repo/' }
+    }
+}
+
 subprojects {
     apply plugin: 'java'
 
@@ -63,15 +74,6 @@ subprojects {
     }
     if (!project.hasProperty('mainClass')) { // must use project.hasProperty() rather than hasProperty in subprojects (gradle bug)
         ext.mainClass = ''
-    }
-
-    repositories {
-        mavenLocal()
-        mavenCentral()
-        maven { url "https://oss.sonatype.org/content/repositories/releases" }
-        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
-        maven { url 'https://maven.java.net/content/repositories/snapshots' }
-        maven { url 'http://www.allanbank.com/repo/' }
     }
 
     configurations {
@@ -460,6 +462,14 @@ subprojects {
     }	
 }
 
+configurations {
+    markdownDoclet
+}
+
+dependencies {
+    markdownDoclet "ch.raffael.pegdown-doclet:pegdown-doclet:1.1.1"
+}
+
 task javadoc(type: Javadoc) {
     title = "Comsat ${project(':comsat-actors-api').version}"
     destinationDir = file("docs/javadoc")
@@ -467,6 +477,7 @@ task javadoc(type: Javadoc) {
     classpath = files(subprojects.collect { project -> project.sourceSets.main.compileClasspath })
     options {
         addStringOption('sourcepath', subprojects.configurations.srcFiles.files.flatten().join(':'))
+        docletpath = configurations.markdownDoclet.files.asType(List)
         doclet = 'ch.raffael.doclets.pegdown.PegdownDoclet'
         addStringOption("parse-timeout", "10")
         // stylesheetFile = rootProject.file('./baselib/javadoc.css')
@@ -496,4 +507,3 @@ task wrapper(type: Wrapper) {
 }
 
 defaultTasks 'install'
-


### PR DESCRIPTION
JavaDocs build was broken for me (lubuntu Virtualbox VM 14.10 both jdk8 and jdk7, using "gradlew", tried on tag as well): it was complaining about missing Pegdown doclet (because of unspecified docletpath).

I'm no Gradle evangelist but I tried to factor out at least repositories in a "allprojects" section; I think it could be possible to factor out even more (JavaDocs links seem to need some fixes as well).
