### PR TITLE
Tune the number of dispatch threads dedicated to the reactor.

### DIFF
--- a/comsat-httpclient/src/main/java/co/paralleluniverse/fibers/httpclient/FiberHttpClientBuilder.java
+++ b/comsat-httpclient/src/main/java/co/paralleluniverse/fibers/httpclient/FiberHttpClientBuilder.java
@@ -57,11 +57,11 @@ public class FiberHttpClientBuilder {
     }
 
     /**
-     * Creates Builder with 10 io threads.
+     * Creates Builder with one io thread per processor.
      * @return
      */
     public static FiberHttpClientBuilder create() {
-        return create(10);
+        return create(Runtime.getRuntime().availableProcessors());
     }
 
     /**

--- a/comsat-httpclient/src/main/java/co/paralleluniverse/fibers/httpclient/FiberHttpClientBuilder.java
+++ b/comsat-httpclient/src/main/java/co/paralleluniverse/fibers/httpclient/FiberHttpClientBuilder.java
@@ -57,11 +57,11 @@ public class FiberHttpClientBuilder {
     }
 
     /**
-     * Creates Builder with one io thread per processor.
+     * Creates Builder with one io thread.
      * @return
      */
     public static FiberHttpClientBuilder create() {
-        return create(Runtime.getRuntime().availableProcessors());
+        return create(1);
     }
 
     /**


### PR DESCRIPTION
The default of 10 I/O threads is likely overkill for an httpclient instance.  Instead allocate 1 thread per available processor.