### PR TITLE
exclude clojure get and await - raises warnings.

### DIFF
--- a/comsat-httpkit/src/co/paralleluniverse/fiber/httpkit/client.clj
+++ b/comsat-httpkit/src/co/paralleluniverse/fiber/httpkit/client.clj
@@ -11,6 +11,7 @@
 ; as published by the Free Software Foundation.
 
 (ns ^{:author "circlespainter"} co.paralleluniverse.fiber.httpkit.client
+  (:refer-clojure :exclude [get await])
   (:require [org.httpkit.client :as hc]
             [co.paralleluniverse.pulsar.core :refer [defsfn await]]))
 


### PR DESCRIPTION
I think the PR's title is self explanatory.