### PR TITLE
HttpMessage header name case normalization 

### DIFF
--- a/comsat-actors-api/src/main/java/co/paralleluniverse/comsat/webactors/HttpMessage.java
+++ b/comsat-actors-api/src/main/java/co/paralleluniverse/comsat/webactors/HttpMessage.java
@@ -16,6 +16,7 @@ package co.paralleluniverse.comsat.webactors;
 import com.google.common.collect.ListMultimap;
 import java.nio.charset.Charset;
 import java.util.Collection;
+import java.util.Locale;
 
 /**
  * A message sent over an HTTP connection. Can be either a request or a response.
@@ -24,6 +25,9 @@ public abstract class HttpMessage extends WebMessage {
     /**
      * A multimap of the headers contained in this message and (all) their values.
      * If the request has no headers, returns an empty multimap.
+     *
+     * Note that header names' case is not preserved necessarily due to normalization for
+     * concordance with the HTTP specification.
      */
     public abstract ListMultimap<String, String> getHeaders();
 
@@ -66,11 +70,13 @@ public abstract class HttpMessage extends WebMessage {
      * If the header is not found in the message, this method returns {@code null}.
      * If the header has more than one value, this method returns the first value.
      *
+     * In concordance with the HTTP specification, this method treats HTTP header names as case-insensitive.
+     *
      * @param name the header name
      * @return the (first) value of the given header name; {@code null} if the header is not found
      */
     public String getHeader(String name) {
-        return first(getHeaders().get(name));
+        return first(getHeaders().get(name.toLowerCase(Locale.ENGLISH)));
     }
 
     static <V> V first(Collection<V> c) {

--- a/comsat-actors-api/src/main/java/co/paralleluniverse/comsat/webactors/HttpRequest.java
+++ b/comsat-actors-api/src/main/java/co/paralleluniverse/comsat/webactors/HttpRequest.java
@@ -364,7 +364,8 @@ public abstract class HttpRequest extends HttpMessage {
         public Builder addHeader(final String name, final String value) {
             if (headers == null)
                 headers = LinkedListMultimap.create();
-            headers.put(name, value);
+            // Normalize header names by their conversion to lower case
+            headers.put(name.toLowerCase(Locale.ENGLISH), value);
             return this;
         }
 

--- a/comsat-actors-netty/src/main/java/co/paralleluniverse/comsat/webactors/netty/HttpRequestWrapper.java
+++ b/comsat-actors-netty/src/main/java/co/paralleluniverse/comsat/webactors/netty/HttpRequestWrapper.java
@@ -310,7 +310,8 @@ final class HttpRequestWrapper extends HttpRequest {
         if (headers != null) {
             final ImmutableListMultimap.Builder<String, String> builder = ImmutableListMultimap.builder();
             for (final String n : headers.names())
-                builder.putAll(n, headers.getAll(n));
+                // Normalize header names by their conversion to lower case
+                builder.putAll(n.toLowerCase(Locale.ENGLISH), headers.getAll(n));
             return builder.build();
         }
         return null;

--- a/comsat-actors-netty/src/test/java/co/paralleluniverse/comsat/webactors/netty/HttpRequestWrapperTest.java
+++ b/comsat-actors-netty/src/test/java/co/paralleluniverse/comsat/webactors/netty/HttpRequestWrapperTest.java
@@ -1,0 +1,26 @@
+package co.paralleluniverse.comsat.webactors.netty;
+
+import io.netty.buffer.EmptyByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author rodedb
+ */
+public class HttpRequestWrapperTest {
+
+    @Test
+    public void httpHeaderCaseInsensitivity() {
+        DefaultFullHttpRequest httpRequest =
+                new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "uri", new EmptyByteBuf(UnpooledByteBufAllocator.DEFAULT));
+        String headerValue = "application/json";
+        httpRequest.headers().add("Content-Type", headerValue);
+        HttpRequestWrapper requestWrapper = new HttpRequestWrapper(null, null, httpRequest, "sessionId");
+        assertEquals(headerValue, requestWrapper.getHeader("content-type"));
+    }
+}

--- a/comsat-actors-servlet/build.gradle
+++ b/comsat-actors-servlet/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    testCompile "org.springframework:spring-test:$springVer"
+}

--- a/comsat-actors-servlet/src/main/java/co/paralleluniverse/comsat/webactors/servlet/HttpRequestWrapper.java
+++ b/comsat-actors-servlet/src/main/java/co/paralleluniverse/comsat/webactors/servlet/HttpRequestWrapper.java
@@ -33,6 +33,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Collection;
 import java.util.Enumeration;
+import java.util.Locale;
 import java.util.Map;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
@@ -130,7 +131,8 @@ final class HttpRequestWrapper extends HttpRequest {
             for (final Enumeration<String> hs = request.getHeaderNames(); hs.hasMoreElements();) {
                 final String h = hs.nextElement();
                 for (final Enumeration<String> hv = request.getHeaders(h); hv.hasMoreElements();)
-                    mm.put(h, hv.nextElement());
+                    // Normalize header names by their conversion to lower case
+                    mm.put(h.toLowerCase(Locale.ENGLISH), hv.nextElement());
             }
             this.headers = mm.build();
         }

--- a/comsat-actors-servlet/src/test/java/co/paralleluniverse/comsat/webactors/servlet/HttpRequestWrapperTest.java
+++ b/comsat-actors-servlet/src/test/java/co/paralleluniverse/comsat/webactors/servlet/HttpRequestWrapperTest.java
@@ -1,0 +1,21 @@
+package co.paralleluniverse.comsat.webactors.servlet;
+
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author rodedb
+ */
+public class HttpRequestWrapperTest {
+
+    @Test
+    public void httpHeaderCaseInsensitivity() {
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+        String headerValue = "application/json";
+        mockRequest.addHeader("Authorization", headerValue);
+        HttpRequestWrapper requestWrapper = new HttpRequestWrapper(null, mockRequest, null);
+        assertEquals(headerValue, requestWrapper.getHeader("authorization"));
+    }
+}

--- a/comsat-actors-undertow/src/main/java/co/paralleluniverse/comsat/webactors/undertow/HttpRequestWrapper.java
+++ b/comsat-actors-undertow/src/main/java/co/paralleluniverse/comsat/webactors/undertow/HttpRequestWrapper.java
@@ -32,10 +32,7 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.UnsupportedCharsetException;
-import java.util.Collection;
-import java.util.Deque;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * @author circlespainter
@@ -64,7 +61,8 @@ final class HttpRequestWrapper extends HttpRequest {
         if (headers != null) {
             final ImmutableListMultimap.Builder<String, String> builder = ImmutableListMultimap.builder();
             for (final HttpString n : headers.getHeaderNames())
-                builder.putAll(n.toString(), headers.get(n));
+                // Normalize header names by their conversion to lower case
+                builder.putAll(n.toString().toLowerCase(Locale.ENGLISH), headers.get(n));
             return builder.build();
         }
         return null;

--- a/comsat-actors-undertow/src/test/java/co/paralleluniverse/comsat/webactors/undertow/HttpRequestWrapperTest.java
+++ b/comsat-actors-undertow/src/test/java/co/paralleluniverse/comsat/webactors/undertow/HttpRequestWrapperTest.java
@@ -1,0 +1,22 @@
+package co.paralleluniverse.comsat.webactors.undertow;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author rodedb
+ */
+public class HttpRequestWrapperTest {
+
+    @Test
+    public void httpHeaderCaseInsensitivity() {
+        String headerValue = "application/json";
+        HttpServerExchange httpServerExchange = new HttpServerExchange(null);
+        httpServerExchange.getRequestHeaders().put(new HttpString("Content-Type"), headerValue);
+        HttpRequestWrapper requestWrapper = new HttpRequestWrapper(null, httpServerExchange, null);
+        assertEquals(headerValue, requestWrapper.getHeader("content-type"));
+    }
+}


### PR DESCRIPTION
https://github.com/puniverse/comsat/pull/66

I seem to have forgot `HttpRequest.Builder` last time.
Do tell if I missed anything.
(why is this not automatically mergeable though?)