### PR TITLE
Add missing Jersey suspendables for request and response filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ tomcat.8080
 /comsat-ring-jetty9/pom.xml.asc
 /comsat-httpkit/pom.xml
 /comsat-httpkit/pom.xml.asc
+.project
+.classpath
+.settings/
+bin/

--- a/comsat-jersey-server/src/main/resources/META-INF/suspendable-supers
+++ b/comsat-jersey-server/src/main/resources/META-INF/suspendable-supers
@@ -1,0 +1,3 @@
+javax.ws.rs.container.ContainerRequestFilter.filter
+javax.ws.rs.container.ContainerResponseFilter.filter
+org.glassfish.jersey.process.internal.Stage.apply

--- a/comsat-jersey-server/src/main/resources/META-INF/suspendables
+++ b/comsat-jersey-server/src/main/resources/META-INF/suspendables
@@ -11,9 +11,12 @@ org.glassfish.jersey.server.model.ResourceMethodInvoker.apply
 org.glassfish.jersey.server.ServerRuntime$Responder.process
 org.glassfish.jersey.server.ServerRuntime$1.run
 org.glassfish.jersey.server.ServerRuntime$2.run
+org.glassfish.jersey.server.ContainerFilteringStage.apply
+org.glassfish.jersey.server.ContainerFilteringStage$ResponseFilterStage.apply
 org.glassfish.jersey.internal.Errors$1.call
 org.glassfish.jersey.internal.Errors.process
 org.glassfish.jersey.process.internal.RequestScope.runInScope
+org.glassfish.jersey.process.internal.Stages.process
 org.glassfish.jersey.server.ServerRuntime.process
 org.glassfish.jersey.server.ApplicationHandler.handle
 org.glassfish.jersey.servlet.internal.ResponseWriter.failure

--- a/comsat-jersey-server/src/test/java/co/paralleluniverse/fibers/jersey/AddTestFiltersFeature.java
+++ b/comsat-jersey-server/src/test/java/co/paralleluniverse/fibers/jersey/AddTestFiltersFeature.java
@@ -1,0 +1,58 @@
+package co.paralleluniverse.fibers.jersey;
+
+import java.io.IOException;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.ext.Provider;
+
+import co.paralleluniverse.fibers.Fiber;
+import co.paralleluniverse.fibers.SuspendExecution;
+import co.paralleluniverse.fibers.Suspendable;
+
+@Provider
+public class AddTestFiltersFeature implements Feature {
+
+    @Override
+    public boolean configure(FeatureContext context) {
+        context.register(TestRequestFilter.class);
+        context.register(TestResponseFilter.class);
+        return true;
+    }
+
+}
+
+class TestRequestFilter implements ContainerRequestFilter {
+
+    @Override
+    @Suspendable
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        try {
+            Fiber.sleep(5);
+            requestContext.getHeaders().add(FiberServletContainerTest.REQUEST_FILTER_HEADER,
+                    FiberServletContainerTest.REQUEST_FILTER_HEADER_VALUE);
+        } catch (InterruptedException | SuspendExecution e) {
+            throw new Error(e);
+        }
+    }
+}
+
+class TestResponseFilter implements ContainerResponseFilter {
+
+    @Override
+    @Suspendable
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+            throws IOException {
+        try {
+            Fiber.sleep(5);
+            responseContext.getHeaders().add(FiberServletContainerTest.RESPONSE_FILTER_HEADER,
+                    FiberServletContainerTest.RESPONSE_FILTER_HEADER_VALUE);
+        } catch (InterruptedException | SuspendExecution e) {
+            throw new Error(e);
+        }
+    }
+}

--- a/comsat-jersey-server/src/test/java/co/paralleluniverse/fibers/jersey/FiberServletContainerTest.java
+++ b/comsat-jersey-server/src/test/java/co/paralleluniverse/fibers/jersey/FiberServletContainerTest.java
@@ -13,20 +13,19 @@
  */
 package co.paralleluniverse.fibers.jersey;
 
-import co.paralleluniverse.common.util.Debug;
-import co.paralleluniverse.embedded.containers.EmbeddedServer;
-import co.paralleluniverse.embedded.containers.JettyServer;
-import co.paralleluniverse.embedded.containers.TomcatServer;
-import co.paralleluniverse.embedded.containers.UndertowServer;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.BasicResponseHandler;
+import org.apache.http.impl.client.AbstractResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import org.junit.Before;
@@ -38,6 +37,12 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import co.paralleluniverse.common.util.Debug;
+import co.paralleluniverse.embedded.containers.EmbeddedServer;
+import co.paralleluniverse.embedded.containers.JettyServer;
+import co.paralleluniverse.embedded.containers.TomcatServer;
+import co.paralleluniverse.embedded.containers.UndertowServer;
 
 @RunWith(Parameterized.class)
 public class FiberServletContainerTest {
@@ -82,14 +87,22 @@ public class FiberServletContainerTest {
     @Test
     public void testGet() throws IOException, InterruptedException, Exception {
         for (int i = 0; i < 10; i++)
-            assertEquals("sleep was 10", client.execute(new HttpGet("http://localhost:8080/service?sleep=10"), BASIC_RESPONSE_HANDLER));
+            client.execute(new HttpGet("http://localhost:8080/service?sleep=10"), TEST_RESPONSE_HANDLER);
     }
 
     @Test
     public void testPost() throws IOException, InterruptedException, Exception {
         for (int i = 0; i < 10; i++)
-            assertEquals("sleep was 10", client.execute(new HttpPost("http://localhost:8080/service?sleep=10"), BASIC_RESPONSE_HANDLER));
+            client.execute(new HttpPost("http://localhost:8080/service?sleep=10"), TEST_RESPONSE_HANDLER);
     }
+
+    private static final ResponseHandler<Void> TEST_RESPONSE_HANDLER = new AbstractResponseHandler<Void>() {
+        @Override
+        public Void handleEntity(HttpEntity entity) throws IOException {
+            assertEquals("sleep was 10", EntityUtils.toString(entity));
+            return null;
+        }
+    };
 
     @Rule
     public TestName name = new TestName();
@@ -118,6 +131,5 @@ public class FiberServletContainerTest {
             Debug.record(0, "DONE TEST " + desc.getMethodName());
         }
     };
-    private static final BasicResponseHandler BASIC_RESPONSE_HANDLER = new BasicResponseHandler();
 
 }

--- a/comsat-jersey-server/src/test/java/co/paralleluniverse/fibers/jersey/FiberServletContainerTest.java
+++ b/comsat-jersey-server/src/test/java/co/paralleluniverse/fibers/jersey/FiberServletContainerTest.java
@@ -13,11 +13,17 @@
  */
 package co.paralleluniverse.fibers.jersey;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.apache.http.Header;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
@@ -27,7 +33,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.junit.After;
-import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -63,6 +68,14 @@ public class FiberServletContainerTest {
         this.cls = cls;
     }
     private static final String PACKAGE_NAME_PREFIX = FiberServletContainerTest.class.getPackage().getName() + ".";
+
+    public static final String REQUEST_FILTER_HEADER = "test.filter.request.header";
+
+    public static final String REQUEST_FILTER_HEADER_VALUE = "ok";
+
+    public static final String RESPONSE_FILTER_HEADER = "test.filter.request.header";
+
+    public static final String RESPONSE_FILTER_HEADER_VALUE = "ok";
 
     @Before
     public void setUp() throws Exception {
@@ -101,6 +114,14 @@ public class FiberServletContainerTest {
         public Void handleEntity(HttpEntity entity) throws IOException {
             assertEquals("sleep was 10", EntityUtils.toString(entity));
             return null;
+        }
+
+        @Override
+        public Void handleResponse(HttpResponse response) throws HttpResponseException, IOException {
+            Header h = response.getFirstHeader(RESPONSE_FILTER_HEADER);
+            assertNotNull(h);
+            assertEquals(RESPONSE_FILTER_HEADER_VALUE, h.getValue());
+            return super.handleResponse(response);
         }
     };
 

--- a/comsat-jersey-server/src/test/java/co/paralleluniverse/fibers/jersey/TestResource.java
+++ b/comsat-jersey-server/src/test/java/co/paralleluniverse/fibers/jersey/TestResource.java
@@ -13,16 +13,17 @@
  */
 package co.paralleluniverse.fibers.jersey;
 
-import co.paralleluniverse.fibers.Fiber;
-import co.paralleluniverse.fibers.SuspendExecution;
-import co.paralleluniverse.fibers.Suspendable;
-import java.io.IOException;
 import javax.inject.Singleton;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+
+import co.paralleluniverse.fibers.Fiber;
+import co.paralleluniverse.fibers.SuspendExecution;
+import co.paralleluniverse.fibers.Suspendable;
 
 // snippet REST resource example
 @Singleton
@@ -31,16 +32,26 @@ public class TestResource {
     @GET
     @Produces("text/plain")
     @Suspendable  // <------------- FIBER
-    public String get(@QueryParam("sleep") int sleep) throws IOException, SuspendExecution, InterruptedException {
+    public String get(@QueryParam("sleep") int sleep,
+            @HeaderParam(FiberServletContainerTest.REQUEST_FILTER_HEADER) String h)
+            throws SuspendExecution, InterruptedException {
         Fiber.sleep(sleep); // <--- you may use fiber blocking calls here
-        return "sleep was "+sleep;
+        // ensure the request filter was called
+        if (FiberServletContainerTest.REQUEST_FILTER_HEADER_VALUE.equals(h)) {
+            return "sleep was " + sleep;
+        } else {
+            return "missing header!";
+        }
+
     }
     // snippet_exclude_begin
     @POST
     @Produces("text/plain")
     @Suspendable  // <------------- FIBER
-    public String post(@QueryParam("sleep") int sleep) throws IOException, SuspendExecution, InterruptedException {
-        return get(sleep);
+    public String post(@QueryParam("sleep") int sleep,
+            @HeaderParam(FiberServletContainerTest.REQUEST_FILTER_HEADER) String h)
+            throws SuspendExecution, InterruptedException {
+        return get(sleep, h);
     }
     // snippet_exclude_end
 }


### PR DESCRIPTION
As discussed on the [mailing-list](https://groups.google.com/d/msg/comsat-user/SQYV9FAKREY/SfIV8QYgBgAJ), here is a PR to add some suspendables in Jersey.

I put all the commits I had a need for (in particular some ignore for Eclipse) but I can remove whichever you want and merge the last two if you prefer :)

Also, in Eclipse, I had to add a compile dependency for quasar-core (in the global dependencies scope), because Eclipse wouldn't add it from the quasar configuration's one otherwise. I didn't commit that, but if you know of a clean way to fix that problem, I'm interested :)