### PR TITLE
Make HttpRequest implementation publicly usable

### DIFF
--- a/comsat-actors-netty/src/main/java/co/paralleluniverse/comsat/webactors/netty/AutoWebActorHandler.java
+++ b/comsat-actors-netty/src/main/java/co/paralleluniverse/comsat/webactors/netty/AutoWebActorHandler.java
@@ -126,7 +126,7 @@ public class AutoWebActorHandler extends WebActorHandler {
         }
 
         private String getSessionId(FullHttpRequest req) {
-            final Set<Cookie> cookies = HttpRequestWrapper.getNettyCookies(req);
+            final Set<Cookie> cookies = NettyHttpRequest.getNettyCookies(req);
             if (cookies != null) {
                 for (final Cookie c : cookies) {
                     if (c != null && SESSION_COOKIE_KEY.equals(c.name()))

--- a/comsat-actors-netty/src/main/java/co/paralleluniverse/comsat/webactors/netty/NettyHttpRequest.java
+++ b/comsat-actors-netty/src/main/java/co/paralleluniverse/comsat/webactors/netty/NettyHttpRequest.java
@@ -43,7 +43,7 @@ import static io.netty.handler.codec.http.HttpHeaders.Names.*;
 /**
  * @author circlespainter
  */
-final class HttpRequestWrapper extends HttpRequest {
+public final class NettyHttpRequest extends HttpRequest {
     public static final String CHARSET_MARKER_STRING = "charset=";
 
     final ActorRef<? super HttpResponse> actorRef;
@@ -65,7 +65,7 @@ final class HttpRequestWrapper extends HttpRequest {
     private Charset encoding;
     private String contentType;
 
-    public HttpRequestWrapper(ActorRef<? super HttpResponse> actorRef, ChannelHandlerContext ctx, FullHttpRequest req, String sessionId) {
+    public NettyHttpRequest(ActorRef<? super HttpResponse> actorRef, ChannelHandlerContext ctx, FullHttpRequest req, String sessionId) {
         this.actorRef = actorRef;
         this.ctx = ctx;
         this.req = req;
@@ -264,6 +264,14 @@ final class HttpRequestWrapper extends HttpRequest {
 
     public final String getSessionId() {
         return sessionId;
+    }
+
+    public ChannelHandlerContext getContext() {
+        return ctx;
+    }
+
+    public FullHttpRequest getRequest() {
+        return req;
     }
 
     private String decodeStringBody() {

--- a/comsat-actors-netty/src/main/java/co/paralleluniverse/comsat/webactors/netty/WebActorHandler.java
+++ b/comsat-actors-netty/src/main/java/co/paralleluniverse/comsat/webactors/netty/WebActorHandler.java
@@ -271,7 +271,7 @@ public class WebActorHandler extends SimpleChannelInboundHandler<Object> {
                         addActorToContextAndUnlock(actorCtx, internalActor, lock);
                     }
                     //noinspection unchecked
-                    ((HttpActorAdapter) internalActor).handleRequest(new HttpRequestWrapper(internalActor.ref(), ctx, req, sessionId));
+                    ((HttpActorAdapter) internalActor).handleRequest(new NettyHttpRequest(internalActor.ref(), ctx, req, sessionId));
                     return;
                 }
             }
@@ -489,7 +489,7 @@ public class WebActorHandler extends SimpleChannelInboundHandler<Object> {
             return false;
         }
 
-        final void handleRequest(HttpRequestWrapper s) throws SuspendExecution, InterruptedException {
+        final void handleRequest(NettyHttpRequest s) throws SuspendExecution, InterruptedException {
             blockSessionRequests();
 
             ctx = s.ctx;
@@ -506,7 +506,7 @@ public class WebActorHandler extends SimpleChannelInboundHandler<Object> {
         @Suspendable
         final void handleReply(HttpResponse message) throws SuspendExecution, InterruptedException {
             try {
-                final HttpRequestWrapper nettyRequest = (HttpRequestWrapper) message.getRequest();
+                final NettyHttpRequest nettyRequest = (NettyHttpRequest) message.getRequest();
                 final FullHttpRequest req = nettyRequest.req;
                 final ChannelHandlerContext ctx = nettyRequest.ctx;
                 final String sessionId = nettyRequest.getSessionId();
@@ -788,7 +788,7 @@ public class WebActorHandler extends SimpleChannelInboundHandler<Object> {
 
         public HttpStreamChannelAdapter(ChannelHandlerContext ctx, FullHttpRequest req) {
             this.ctx = ctx;
-            this.encoding = HttpRequestWrapper.extractCharacterEncodingOrDefault(req.headers());
+            this.encoding = NettyHttpRequest.extractCharacterEncodingOrDefault(req.headers());
         }
 
         @Override

--- a/comsat-actors-netty/src/test/java/co/paralleluniverse/comsat/webactors/netty/HttpRequestWrapperTest.java
+++ b/comsat-actors-netty/src/test/java/co/paralleluniverse/comsat/webactors/netty/HttpRequestWrapperTest.java
@@ -20,7 +20,7 @@ public class HttpRequestWrapperTest {
                 new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "uri", new EmptyByteBuf(UnpooledByteBufAllocator.DEFAULT));
         String headerValue = "application/json";
         httpRequest.headers().add("Content-Type", headerValue);
-        HttpRequestWrapper requestWrapper = new HttpRequestWrapper(null, null, httpRequest, "sessionId");
+        NettyHttpRequest requestWrapper = new NettyHttpRequest(null, null, httpRequest, "sessionId");
         assertEquals(headerValue, requestWrapper.getHeader("content-type"));
     }
 }

--- a/comsat-actors-servlet/src/main/java/co/paralleluniverse/comsat/webactors/servlet/ServletHttpRequest.java
+++ b/comsat-actors-servlet/src/main/java/co/paralleluniverse/comsat/webactors/servlet/ServletHttpRequest.java
@@ -42,7 +42,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * Wraps a {@link HttpServletRequest} as a {@link HttpRequest}
  */
-final class HttpRequestWrapper extends HttpRequest {
+public final class ServletHttpRequest extends HttpRequest {
     final HttpServletRequest request;
     final HttpServletResponse response;
 
@@ -61,10 +61,18 @@ final class HttpRequestWrapper extends HttpRequest {
      * @param request the {@link HttpServletRequest}
      * @param response the {@link HttpServletResponse}
      */
-    public HttpRequestWrapper(ActorRef<? super HttpResponse> sender, HttpServletRequest request, HttpServletResponse response) {
+    public ServletHttpRequest(ActorRef<? super HttpResponse> sender, HttpServletRequest request, HttpServletResponse response) {
         this.sender = sender;
         this.request = request;
         this.response = response;
+    }
+
+    public HttpServletRequest getServletRequest() {
+        return request;
+    }
+
+    public HttpServletResponse getServletResponse() {
+        return response;
     }
 
     @Override

--- a/comsat-actors-servlet/src/main/java/co/paralleluniverse/comsat/webactors/servlet/WebActorServlet.java
+++ b/comsat-actors-servlet/src/main/java/co/paralleluniverse/comsat/webactors/servlet/WebActorServlet.java
@@ -286,7 +286,7 @@ public final class WebActorServlet extends HttpServlet implements HttpSessionLis
             this.res = resp;
 
             //noinspection unchecked
-            userWebActorRef.send(new HttpRequestWrapper(ref(), req, resp));
+            userWebActorRef.send(new ServletHttpRequest(ref(), req, resp));
         }
 
         @Suspendable
@@ -415,7 +415,7 @@ public final class WebActorServlet extends HttpServlet implements HttpSessionLis
         final void handleReply(final HttpResponse msg) throws SuspendExecution {
             HttpServletRequest request;
             try {
-                request = ((HttpRequestWrapper) msg.getRequest()).request;
+                request = ((ServletHttpRequest) msg.getRequest()).request;
 
                 final AsyncContext ctx = request.getAsyncContext();
                 final HttpServletResponse response = (HttpServletResponse) ctx.getResponse();

--- a/comsat-actors-servlet/src/test/java/co/paralleluniverse/comsat/webactors/servlet/HttpRequestWrapperTest.java
+++ b/comsat-actors-servlet/src/test/java/co/paralleluniverse/comsat/webactors/servlet/HttpRequestWrapperTest.java
@@ -15,7 +15,7 @@ public class HttpRequestWrapperTest {
         MockHttpServletRequest mockRequest = new MockHttpServletRequest();
         String headerValue = "application/json";
         mockRequest.addHeader("Authorization", headerValue);
-        HttpRequestWrapper requestWrapper = new HttpRequestWrapper(null, mockRequest, null);
+        ServletHttpRequest requestWrapper = new ServletHttpRequest(null, mockRequest, null);
         assertEquals(headerValue, requestWrapper.getHeader("authorization"));
     }
 }

--- a/comsat-actors-undertow/src/main/java/co/paralleluniverse/comsat/webactors/undertow/UndertowHttpRequest.java
+++ b/comsat-actors-undertow/src/main/java/co/paralleluniverse/comsat/webactors/undertow/UndertowHttpRequest.java
@@ -37,7 +37,7 @@ import java.util.*;
 /**
  * @author circlespainter
  */
-final class HttpRequestWrapper extends HttpRequest {
+public final class UndertowHttpRequest extends HttpRequest {
     final ActorRef<? super HttpResponse> actorRef;
     final HttpServerExchange xch;
     private final ByteBuffer reqContent;
@@ -51,10 +51,14 @@ final class HttpRequestWrapper extends HttpRequest {
     private String contentType;
     private Charset encoding;
 
-    public HttpRequestWrapper(ActorRef<? super HttpResponse> actorRef, HttpServerExchange xch, ByteBuffer reqContent) {
+    public UndertowHttpRequest(ActorRef<? super HttpResponse> actorRef, HttpServerExchange xch, ByteBuffer reqContent) {
         this.actorRef = actorRef;
         this.xch = xch;
         this.reqContent = reqContent;
+    }
+
+    public HttpServerExchange getServerExchange() {
+        return xch;
     }
 
     static ImmutableListMultimap<String, String> extractHeaders(HeaderMap headers) {

--- a/comsat-actors-undertow/src/main/java/co/paralleluniverse/comsat/webactors/undertow/WebActorHandler.java
+++ b/comsat-actors-undertow/src/main/java/co/paralleluniverse/comsat/webactors/undertow/WebActorHandler.java
@@ -252,7 +252,7 @@ public class WebActorHandler implements HttpHandler {
                                         protected final void byteArrayDone(final byte[] ba) {
                                             try {
                                                 // adapter.ch.send(new HttpRequestWrapper(adapter.ref(), xch, ByteBuffer.wrap(ba)));
-                                                adapter.handleRequest(new HttpRequestWrapper(adapter.ref(), xch, ByteBuffer.wrap(ba)));
+                                                adapter.handleRequest(new UndertowHttpRequest(adapter.ref(), xch, ByteBuffer.wrap(ba)));
                                             } catch (final SuspendExecution e) {
                                                 throw new AssertionError(e);
                                             } catch (final InterruptedException e) {
@@ -485,7 +485,7 @@ public class WebActorHandler implements HttpHandler {
         }
 
         @Suspendable
-        final void handleRequest(HttpRequestWrapper s) throws SuspendExecution, InterruptedException {
+        final void handleRequest(UndertowHttpRequest s) throws SuspendExecution, InterruptedException {
             blockSessionRequests();
             xch = s.xch;
             if (needsRestart) {
@@ -499,7 +499,7 @@ public class WebActorHandler implements HttpHandler {
 
         final void handleReply(final HttpResponse message) throws InterruptedException {
             try {
-                final HttpRequestWrapper undertowRequest = (HttpRequestWrapper) message.getRequest();
+                final UndertowHttpRequest undertowRequest = (UndertowHttpRequest) message.getRequest();
                 final HttpServerExchange xch = undertowRequest.xch;
 
                 final int status = message.getStatus();

--- a/comsat-actors-undertow/src/test/java/co/paralleluniverse/comsat/webactors/undertow/HttpRequestWrapperTest.java
+++ b/comsat-actors-undertow/src/test/java/co/paralleluniverse/comsat/webactors/undertow/HttpRequestWrapperTest.java
@@ -16,7 +16,7 @@ public class HttpRequestWrapperTest {
         String headerValue = "application/json";
         HttpServerExchange httpServerExchange = new HttpServerExchange(null);
         httpServerExchange.getRequestHeaders().put(new HttpString("Content-Type"), headerValue);
-        HttpRequestWrapper requestWrapper = new HttpRequestWrapper(null, httpServerExchange, null);
+        UndertowHttpRequest requestWrapper = new UndertowHttpRequest(null, httpServerExchange, null);
         assertEquals(headerValue, requestWrapper.getHeader("content-type"));
     }
 }


### PR DESCRIPTION
- Fixes #76
- Rename HttpRequestWrapper to {Netty,Undertow,Servlet}HttpRequest
- Make them public class
- Give access to each specific implementation underlying mechanisms
  through getters